### PR TITLE
Allow Custom configs as props

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "packageManager": "yarn@1.22.19",
   "workspaces": [
     "src/plugins/*",
-    "src/",
+    "src",
     "storybook",
     "OutputInspectorAddon"
   ],

--- a/src/editor/BubbleMenu.tsx
+++ b/src/editor/BubbleMenu.tsx
@@ -129,37 +129,38 @@ export const OrderedListButton = ({ editor }: MenuButtonProps) => {
   );
 };
 
-// TODO: Needs better UI
+// TODO: probably needs better UI, heading should probably be a select of something instead of a bunch of buttons
+const HeadingButton = ({
+  level,
+  editor,
+}: {
+  level: number;
+  editor: Editor;
+}) => {
+  return (
+    <button
+      title={`Heading ${level}`}
+      aria-label={`heading ${level}`}
+      aria-pressed={editor.isActive("heading", { level: level })}
+      onClick={() =>
+        //@ts-ignore
+        editor.chain().focus().toggleHeading({ level: level }).run()
+      }
+      //@ts-ignore
+      hidden={!editor.can().toggleHeading({ level: level })}
+    >
+      <span>{`H${level}`}</span>
+    </button>
+  );
+};
+
 export const HeadingButtons = ({ editor }: MenuButtonProps) => {
+  const headingLevels = [1, 2, 3, 4, 5, 6];
   return (
     <>
-      <button
-        title="Heading 1"
-        aria-label="heading 1"
-        aria-pressed={editor.isActive("heading", { level: 1 })}
-        //@ts-ignore
-        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-      >
-        <span>H1</span>
-      </button>
-      <button
-        title="Heading 2"
-        aria-label="heading 2"
-        aria-pressed={editor.isActive("heading", { level: 2 })}
-        //@ts-ignore
-        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-      >
-        <span>H2</span>
-      </button>
-      <button
-        title="Heading 3"
-        aria-label="heading 3"
-        aria-pressed={editor.isActive("heading", { level: 3 })}
-        //@ts-ignore
-        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-      >
-        <span>H3</span>
-      </button>
+      {headingLevels.map((level) => (
+        <HeadingButton key={level} level={level} editor={editor} />
+      ))}
     </>
   );
 };

--- a/src/package.json
+++ b/src/package.json
@@ -36,6 +36,7 @@
     "@tiptap/extension-document": "^2.0.0-beta.194",
     "@tiptap/extension-floating-menu": "^2.0.0-beta.194",
     "@tiptap/extension-hard-break": "^2.0.0-beta.194",
+    "@tiptap/extension-heading": "^2.0.3",
     "@tiptap/extension-italic": "^2.0.0-beta.220",
     "@tiptap/extension-link": "^2.0.0-beta.220",
     "@tiptap/extension-paragraph": "^2.0.0-beta.194",

--- a/storybook/stories/Editor.stories.tsx
+++ b/storybook/stories/Editor.stories.tsx
@@ -116,6 +116,17 @@ export const ViewOnlyLink: Story = {
   },
 };
 
+export const LimitedHeadings: Story = {
+  args: {
+    ...Editable.args,
+    addedExtensions: [Heading],
+    extensionConfigs: [
+      { extensionName: Heading.name, config: { levels: [1, 2] } },
+    ],
+    initialContent: `<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><p>Regular paragraph</p>`,
+  },
+};
+
 export const AllExtensions: Story = {
   args: {
     ...Editable.args,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3039,6 +3039,11 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-heading/-/extension-heading-2.0.2.tgz#0cc9238b97275c4f290cd579286bf5bd8e235b5d"
   integrity sha512-99PL9Rx8mioo13SNuIkhZm1VW6UuUKKG0b7fAimsunaEbbLNtToXIasS68pX8BkgWnsBfDhR0HyhnpIBRg7W0w==
 
+"@tiptap/extension-heading@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-heading/-/extension-heading-2.0.3.tgz#5e9e779f33f366afcf729d9f68ef49721f825e11"
+  integrity sha512-f0IEv5ms6aCzL80WeZ1qLCXTkRVwbpRr1qAETjg3gG4eoJN18+lZNOJYpyZy3P92C5KwF2T3Av00eFyVLIbb8Q==
+
 "@tiptap/extension-italic@^2.0.0-beta.220":
   version "2.0.0-beta.220"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-italic/-/extension-italic-2.0.0-beta.220.tgz#94e442689f69e694a2a983eabcae0ccc803262b9"


### PR DESCRIPTION
Allows passing custom extension configs as props, plus fixes the `yarn add` error and improves header buttons in bubble menu.