### PR TITLE
Adds base BlockWithMenu plugin and makes Image extend it

### DIFF
--- a/src/editor/BubbleMenu.tsx
+++ b/src/editor/BubbleMenu.tsx
@@ -307,7 +307,11 @@ export const BubbleMenuOptions = ({
           <option.menuButton editor={editor} />
         </li>
       ))}
-      {options.length > 0 && <ClearButton editor={editor} />}
+      {options.length > 0 && (
+        <li role="menuitem">
+          <ClearButton editor={editor} />
+        </li>
+      )}
     </ul>
   );
 };

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -18,18 +18,24 @@
 [data-spoilers="true"] {
   position: relative;
 }
+
 [data-spoilers="true"]::after {
   content: "\A \A Spoilers alert!!";
-  background-color: var(
-    --block-spoilers-background-color,
-    rgba(255, 0, 0, 0.3)
-  );
+  background-color: var(--block-spoilers-background-color, rgba(255, 0, 0));
   background-image: var(--block-spoilers-image-url);
   width: 100%;
   height: 100%;
   position: absolute;
   top: 0;
   white-space: pre;
+}
+
+.ProseMirror[contenteditable="true"] [data-spoilers="true"]::after {
+  opacity: 0.3;
+}
+
+[data-spoilers="true"][data-visible="true"]::after {
+  display: none;
 }
 
 [data-type="inlineSpoilers"] {

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -18,16 +18,15 @@
 .base-block {
   background-color: cornflowerblue;
 }
-/* TODO: figure out clicking image */
+
 [data-spoilers="true"] {
   position: relative;
   display: block;
-  z-index: 9;
   cursor: pointer;
 }
 
 [data-spoilers="true"]::after {
-  content: "\A \A Spoilers alert!!";
+  content: "";
   background-color: var(--block-spoilers-background-color, rgba(255, 0, 0));
   background-image: var(--block-spoilers-image-url, url(https://firebasestorage.googleapis.com/v0/b/bobaboard-fb.appspot.com/o/images%2Fadmin%2Fspoilers.png?alt=media&token=a343aee0-e90f-4379-8d41-1cac1f65f7ee));
   background-size: cover;

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -6,6 +6,15 @@
   background-color: var(--active-button-background-color, blueviolet);
 }
 
+[role="menubar"] {
+  display: flex;
+  list-style: none;
+}
+
+[data-type="blockWithMenu"] {
+  background-color: cornflowerblue;
+}
+
 [data-spoilers="true"] {
   position: relative;
 }

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -2,6 +2,10 @@
   padding: 5px;
 }
 
+.ProseMirror {
+  isolation: isolate;
+}
+
 [role="menuitem"] [aria-pressed="true"] {
   background-color: var(--active-button-background-color, blueviolet);
 }
@@ -14,24 +18,28 @@
 .base-block {
   background-color: cornflowerblue;
 }
-
+/* TODO: figure out clicking image */
 [data-spoilers="true"] {
   position: relative;
+  display: block;
+  z-index: 9;
+  cursor: pointer;
 }
 
 [data-spoilers="true"]::after {
   content: "\A \A Spoilers alert!!";
   background-color: var(--block-spoilers-background-color, rgba(255, 0, 0));
-  background-image: var(--block-spoilers-image-url);
-  width: 100%;
-  height: 100%;
+  background-image: var(--block-spoilers-image-url, url(https://firebasestorage.googleapis.com/v0/b/bobaboard-fb.appspot.com/o/images%2Fadmin%2Fspoilers.png?alt=media&token=a343aee0-e90f-4379-8d41-1cac1f65f7ee));
+  background-size: cover;
+  background-position: center;
   position: absolute;
-  top: 0;
+  inset: 0;
   white-space: pre;
+  z-index: 99;
 }
 
 .ProseMirror[contenteditable="true"] [data-spoilers="true"]::after {
-  opacity: 0.3;
+  opacity: 0.1;
 }
 
 [data-spoilers="true"][data-visible="true"]::after {

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -3,6 +3,9 @@
 }
 
 .ProseMirror {
+  /* Creates a new stacking context. Will keep any negative z-indexed
+   child elements from slipping behind thing outside of the editor. 
+   Not actually needed yet, but a good failsafe. */
   isolation: isolate;
 }
 

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -11,7 +11,7 @@
   list-style: none;
 }
 
-.block-with-menu {
+.base-block {
   background-color: cornflowerblue;
 }
 

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -11,7 +11,7 @@
   list-style: none;
 }
 
-[data-type="blockWithMenu"] {
+.block-with-menu {
   background-color: cornflowerblue;
 }
 

--- a/src/plugins/BlockSettingsMenu/BlockSettingsMenu.tsx
+++ b/src/plugins/BlockSettingsMenu/BlockSettingsMenu.tsx
@@ -1,3 +1,5 @@
+import { ArrowDown, ArrowUp, EyeAlt, EyeOff, Trash } from "iconoir-react";
+
 import React from "react";
 import { css } from "@linaria/core";
 
@@ -27,6 +29,15 @@ export interface BlockSettingsMenuProps {
   children:
     | React.ReactElement<SettingTypes>
     | React.ReactElement<SettingTypes>[];
+}
+
+export interface BlockBaseMenuProps extends BlockSettingsMenuProps {
+  spoilers: boolean;
+  deleteTitle: string;
+  onToggleSpoilers: (spoilers: boolean) => void;
+  onDeleteRequest: () => void;
+  onInsertAbove: () => void;
+  onInsertBelow: () => void;
 }
 
 export const Button = (props: ButtonProps) => {
@@ -69,6 +80,37 @@ export const BlockSettingsMenu = (props: BlockSettingsMenuProps) => {
           {child}
         </li>
       ))}
+    </ul>
+  );
+};
+
+export const BlockBaseMenu = (props: BlockBaseMenuProps) => {
+  return (
+    <ul role="menubar" className={menuStyle}>
+      {React.Children.map(props.children, (child) => (
+        <li role="menuitem" key={child.props.title}>
+          {child}
+        </li>
+      ))}
+      <ToggleButton
+        value={!!props.spoilers}
+        title="Toggle Spoilers"
+        onValueChange={props.onToggleSpoilers}
+      >
+        {props.spoilers ? <EyeAlt /> : <EyeOff />}
+      </ToggleButton>
+      <Button
+        title={`Delete ${props.deleteTitle}`}
+        onClick={props.onDeleteRequest}
+      >
+        <Trash />
+      </Button>
+      <Button title="Insert Paragraph Above" onClick={props.onInsertAbove}>
+        Insert Paragraph <ArrowUp />
+      </Button>
+      <Button title="Insert Paragraph Below" onClick={props.onInsertBelow}>
+        Insert Paragraph <ArrowDown />
+      </Button>
     </ul>
   );
 };

--- a/src/plugins/BlockSettingsMenu/BlockSettingsMenu.tsx
+++ b/src/plugins/BlockSettingsMenu/BlockSettingsMenu.tsx
@@ -1,5 +1,3 @@
-import { ArrowDown, ArrowUp, EyeAlt, EyeOff, Trash } from "iconoir-react";
-
 import React from "react";
 import { css } from "@linaria/core";
 
@@ -29,15 +27,6 @@ export interface BlockSettingsMenuProps {
   children:
     | React.ReactElement<SettingTypes>
     | React.ReactElement<SettingTypes>[];
-}
-
-export interface BlockBaseMenuProps extends BlockSettingsMenuProps {
-  spoilers: boolean;
-  deleteTitle: string;
-  onToggleSpoilers: (spoilers: boolean) => void;
-  onDeleteRequest: () => void;
-  onInsertAbove: () => void;
-  onInsertBelow: () => void;
 }
 
 export const Button = (props: ButtonProps) => {
@@ -80,37 +69,6 @@ export const BlockSettingsMenu = (props: BlockSettingsMenuProps) => {
           {child}
         </li>
       ))}
-    </ul>
-  );
-};
-
-export const BlockBaseMenu = (props: BlockBaseMenuProps) => {
-  return (
-    <ul role="menubar" className={menuStyle}>
-      {React.Children.map(props.children, (child) => (
-        <li role="menuitem" key={child.props.title}>
-          {child}
-        </li>
-      ))}
-      <ToggleButton
-        value={!!props.spoilers}
-        title="Toggle Spoilers"
-        onValueChange={props.onToggleSpoilers}
-      >
-        {props.spoilers ? <EyeAlt /> : <EyeOff />}
-      </ToggleButton>
-      <Button
-        title={`Delete ${props.deleteTitle}`}
-        onClick={props.onDeleteRequest}
-      >
-        <Trash />
-      </Button>
-      <Button title="Insert Paragraph Above" onClick={props.onInsertAbove}>
-        Insert Paragraph <ArrowUp />
-      </Button>
-      <Button title="Insert Paragraph Below" onClick={props.onInsertBelow}>
-        Insert Paragraph <ArrowDown />
-      </Button>
     </ul>
   );
 };

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -16,6 +16,8 @@ export interface BlockBaseMenuProps extends Partial<BlockSettingsMenuProps> {
   deleteTitle: string;
 }
 
+// We only add buttons here that we want available in all child plugins that will extend BlockWithMenu
+// Additional buttons specific to a given plugin can be added as children.
 export const BlockBaseMenu = (
   props: BlockBaseMenuProps &
     Partial<NodeViewProps> &
@@ -131,6 +133,8 @@ export const EditableBlockWithMenuComponent = (
   return (
     <NodeViewWrapper data-type={PLUGIN_NAME}>
       <BlockBaseMenu {...props} deleteTitle="block">
+        {/* These buttons are intended for testing the BlockWithMenu plugin on it's own.
+        They will not appear in child plugins extended from this one.  */}
         <Button
           title="set width"
           onClick={() => {

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -114,6 +114,7 @@ export const BlockBaseComponent = (props: BlockBaseProps) => {
       style={{
         width: attributes.width,
         height: attributes.height,
+        display: "block",
         maxWidth: "100%",
       }}
     >

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -113,12 +113,38 @@ export const BlockWithMenuComponent = (
 };
 
 export const EditableBlockWithMenuComponent = (
-  props: Partial<NodeViewProps> & Required<Pick<NodeViewProps, "node">>
+  props: Partial<NodeViewProps> &
+    Required<Pick<NodeViewProps, "node" | "editor">>
 ) => {
   const attributes = props.node.attrs as BlockWithMenuOptions;
   return (
     <NodeViewWrapper data-type={PLUGIN_NAME}>
-      <BlockBaseMenu {...props} deleteTitle="block" />
+      <BlockBaseMenu {...props} deleteTitle="block">
+        <Button
+          title="set width"
+          onClick={() => {
+            const width = window.prompt("set width:");
+            if (!width) {
+              return;
+            }
+            props.updateAttributes?.({ width: parseFloat(width) });
+          }}
+        >
+          width
+        </Button>
+        <Button
+          title="set height"
+          onClick={() => {
+            const height = window.prompt("set height:");
+            if (!height) {
+              return;
+            }
+            props.updateAttributes?.({ height: parseFloat(height) });
+          }}
+        >
+          height
+        </Button>
+      </BlockBaseMenu>
       <BlockWithMenuComponent
         spoilers={attributes.spoilers}
         width={attributes.width}

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -98,6 +98,7 @@ export const BlockBaseMenu = (
 export const BlockWithMenuComponent = (props: BlockWithMenuOptions) => {
   return (
     <div
+      className="block-with-menu"
       data-type={PLUGIN_NAME}
       data-spoilers={props.spoilers}
       data-width={props.width}

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -1,6 +1,5 @@
 import { ArrowDown, ArrowUp, EyeAlt, EyeOff, Trash } from "iconoir-react";
 import {
-  BlockSettingsMenu,
   BlockSettingsMenuProps,
   Button,
   ToggleButton,
@@ -15,6 +14,7 @@ export interface BlockBaseMenuProps extends Partial<BlockSettingsMenuProps> {
   deleteTitle: string;
 }
 
+// TODO: debug inserting paragraph above lower of two blocks in a row
 export const BlockBaseMenu = (
   props: BlockBaseMenuProps &
     Partial<NodeViewProps> &
@@ -95,12 +95,16 @@ export const BlockBaseMenu = (
   );
 };
 
-export const BlockWithMenuComponent = (props: BlockWithMenuOptions) => {
+export const BlockWithMenuComponent = (
+  props: BlockWithMenuOptions & { editable?: boolean }
+) => {
   return (
     <div
       className="block-with-menu"
+      tabIndex={props.editable || !props.spoilers ? -1 : 0}
       data-type={PLUGIN_NAME}
       data-spoilers={props.spoilers}
+      data-visible={props.visible}
       data-width={props.width}
       data-height={props.height}
       style={{ width: props.width, height: props.height, maxWidth: "100%" }}

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -14,7 +14,6 @@ export interface BlockBaseMenuProps extends Partial<BlockSettingsMenuProps> {
   deleteTitle: string;
 }
 
-// TODO: debug inserting paragraph above lower of two blocks in a row
 export const BlockBaseMenu = (
   props: BlockBaseMenuProps &
     Partial<NodeViewProps> &
@@ -58,13 +57,9 @@ export const BlockBaseMenu = (
             if (props.getPos) {
               props.editor
                 ?.chain()
-                .insertContentAt(
-                  props.getPos() > 0 ? props.getPos() - 1 : 0,
-                  "<p></p>",
-                  {
-                    updateSelection: true,
-                  }
-                )
+                .insertContentAt(props.getPos(), "<p></p>", {
+                  updateSelection: true,
+                })
                 .focus()
                 .run();
             }

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -7,8 +7,10 @@ import {
 import { BlockWithMenuOptions, PLUGIN_NAME } from "./Plugin";
 import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 
+import { Attrs } from "@tiptap/pm/model";
 import React from "react";
 import { css } from "@linaria/core";
+import { makeDataAttributes } from "../utils";
 
 export interface BlockBaseMenuProps extends Partial<BlockSettingsMenuProps> {
   deleteTitle: string;
@@ -90,20 +92,33 @@ export const BlockBaseMenu = (
   );
 };
 
-export const BlockWithMenuComponent = (
-  props: BlockWithMenuOptions & { editable?: boolean }
-) => {
+export interface BlockBaseProps {
+  pluginName: string;
+  attributes: Attrs;
+  children?: React.ReactNode;
+  enclosingTag?: React.ElementType;
+  editable?: boolean;
+  className?: string;
+}
+
+export const BlockBaseComponent = (props: BlockBaseProps) => {
+  const attributes = props.attributes;
+  const Tag = props.enclosingTag ?? "div";
+  const dataAttributes = makeDataAttributes(attributes);
   return (
-    <div
-      className="block-with-menu"
-      tabIndex={props.editable || !props.spoilers ? -1 : 0}
-      data-type={PLUGIN_NAME}
-      data-spoilers={props.spoilers}
-      data-visible={props.visible}
-      data-width={props.width}
-      data-height={props.height}
-      style={{ width: props.width, height: props.height, maxWidth: "100%" }}
-    ></div>
+    <Tag
+      className={props.className ?? "base-block"}
+      tabIndex={props.editable || !attributes.spoilers ? -1 : 0}
+      data-type={props.pluginName}
+      {...dataAttributes}
+      style={{
+        width: attributes.width,
+        height: attributes.height,
+        maxWidth: "100%",
+      }}
+    >
+      {props.children}
+    </Tag>
   );
 };
 
@@ -140,11 +155,7 @@ export const EditableBlockWithMenuComponent = (
           height
         </Button>
       </BlockBaseMenu>
-      <BlockWithMenuComponent
-        spoilers={attributes.spoilers}
-        width={attributes.width}
-        height={attributes.height}
-      />
+      <BlockBaseComponent pluginName={PLUGIN_NAME} attributes={attributes} />
     </NodeViewWrapper>
   );
 };

--- a/src/plugins/BlockWithMenu/Components.tsx
+++ b/src/plugins/BlockWithMenu/Components.tsx
@@ -1,0 +1,103 @@
+import { ArrowDown, ArrowUp, EyeAlt, EyeOff, Trash } from "iconoir-react";
+import {
+  BlockSettingsMenu,
+  Button,
+  ToggleButton,
+} from "../BlockSettingsMenu/BlockSettingsMenu";
+import { BlockWithMenuOptions, PLUGIN_NAME } from "./Plugin";
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+
+import React from "react";
+import { css } from "@linaria/core";
+
+const OptionsMenu = (props: {
+  spoilers: boolean;
+  onToggleSpoilers: (spoilers: boolean) => void;
+  onDeleteRequest: () => void;
+  onInsertAbove: () => void;
+  onInsertBelow: () => void;
+}) => {
+  return (
+    <BlockSettingsMenu>
+      <ToggleButton
+        value={!!props.spoilers}
+        title="Toggle Spoilers"
+        onValueChange={props.onToggleSpoilers}
+      >
+        {props.spoilers ? <EyeAlt /> : <EyeOff />}
+      </ToggleButton>
+      <Button title="Delete Image" onClick={props.onDeleteRequest}>
+        <Trash />
+      </Button>
+      <Button title="Insert Paragraph Above" onClick={props.onInsertAbove}>
+        Insert Paragraph <ArrowUp />
+      </Button>
+      <Button title="Insert Paragraph Below" onClick={props.onInsertBelow}>
+        Insert Paragraph <ArrowDown />
+      </Button>
+    </BlockSettingsMenu>
+  );
+};
+
+const blockComponentClass = css`
+  div {
+    margin: 0 auto;
+  }
+`;
+
+export const BlockWithMenuComponent = (props: BlockWithMenuOptions) => {
+  return (
+    <div
+      className={blockComponentClass}
+      data-type={PLUGIN_NAME}
+      data-spoilers={props.spoilers}
+      style={{ display: "block", maxWidth: "100%" }}
+    ></div>
+  );
+};
+
+export const EditableBlockWithMenuComponent = (
+  props: Partial<NodeViewProps> & Required<Pick<NodeViewProps, "node">>
+) => {
+  const attributes = props.node.attrs as BlockWithMenuOptions;
+  return (
+    <NodeViewWrapper data-type={PLUGIN_NAME}>
+      <OptionsMenu
+        spoilers={!!attributes.spoilers}
+        onToggleSpoilers={(spoilers) =>
+          props.updateAttributes?.({
+            spoilers,
+          })
+        }
+        onDeleteRequest={() => props.deleteNode?.()}
+        onInsertAbove={() => {
+          if (props.getPos) {
+            props.editor
+              ?.chain()
+              .insertContentAt(
+                props.getPos() > 0 ? props.getPos() - 1 : 0,
+                "<p></p>",
+                {
+                  updateSelection: true,
+                }
+              )
+              .focus()
+              .run();
+          }
+        }}
+        onInsertBelow={() => {
+          if (props.getPos) {
+            props.editor
+              ?.chain()
+              .insertContentAt(props.getPos() + 1, "<p></p>", {
+                updateSelection: true,
+              })
+              .focus()
+              .run();
+          }
+        }}
+      />
+      <BlockWithMenuComponent spoilers={attributes.spoilers} />
+    </NodeViewWrapper>
+  );
+};

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -37,11 +37,17 @@ export const BlockWithMenuPlugin = Node.create<BlockWithMenuOptions>({
       },
       height: {
         default: 300,
-        parseHTML: (element) => element.getAttribute("data-height"),
+        parseHTML: (element) => {
+          const rawHeight = element.getAttribute("data-height");
+          return rawHeight ? parseFloat(rawHeight) : null;
+        },
       },
       width: {
         default: 300,
-        parseHTML: (element) => element.getAttribute("data-height"),
+        parseHTML: (element) => {
+          const rawWidth = element.getAttribute("data-width");
+          return rawWidth ? parseFloat(rawWidth) : null;
+        },
       },
     };
   },
@@ -87,4 +93,6 @@ export const BlockWithMenuPlugin = Node.create<BlockWithMenuOptions>({
         },
     };
   },
+
+  // TODO: make spoilers revealable
 });

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -1,5 +1,6 @@
 import {
-  BlockWithMenuComponent,
+  BlockBaseComponent,
+  BlockBaseProps,
   EditableBlockWithMenuComponent,
 } from "./Components";
 import {
@@ -8,6 +9,7 @@ import {
   toggleAttributeOnClick,
   toggleSpoilersOnKeydown,
   withViewWrapper,
+  withViewWrapperOld,
 } from "../utils";
 
 import { Node } from "@tiptap/core";
@@ -63,17 +65,20 @@ export const BlockWithMenuPlugin = Node.create<BlockWithMenuOptions>({
   },
 
   renderHTML({ node }) {
-    return loadToDom(
-      BlockWithMenuComponent,
-      node.attrs as BlockWithMenuOptions
-    );
+    return loadToDom(BlockBaseComponent, {
+      pluginName: PLUGIN_NAME,
+      attributes: node.attrs,
+    });
   },
 
   addNodeView() {
     return ReactNodeViewRenderer(
       this.editor.isEditable
         ? EditableBlockWithMenuComponent
-        : withViewWrapper(PLUGIN_NAME, BlockWithMenuComponent)
+        : withViewWrapper(PLUGIN_NAME, BlockBaseComponent, {
+            pluginName: PLUGIN_NAME,
+            editable: false,
+          })
     );
   },
 

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -1,0 +1,79 @@
+import { EditableBlockWithMenuComponent, BlockWithMenuComponent } from "./Components";
+import {
+  goToTrailingParagraph,
+  loadToDom,
+  withViewWrapper,
+} from "../utils";
+
+import { Node } from "@tiptap/core";
+import { PluginKey } from "prosemirror-state";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+export const BlockWithMenuPluginKey = new PluginKey("BLockWithMenuPlugin");
+
+export interface BlockWithMenuOptions {
+  width?: number;
+  height?: number;
+  spoilers?: boolean;
+}
+
+export const PLUGIN_NAME = "blockWithMenu";
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    [PLUGIN_NAME]: {
+      setBlock: (options: BlockWithMenuOptions) => ReturnType;
+    };
+  }
+}
+
+export const ImagePlugin = Node.create<BlockWithMenuOptions>({
+  name: PLUGIN_NAME,
+  group: "block",
+
+  addAttributes() {
+    return {
+      spoilers: {
+        default: false,
+      },
+    };
+  },
+
+  renderHTML({ node }) {
+    return loadToDom(BlockWithMenuComponent, node.attrs as BlockWithMenuOptions);
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(
+      this.editor.isEditable
+        ? EditableBlockWithMenuComponent
+        : withViewWrapper(PLUGIN_NAME, BlockWithMenuComponent)
+    );
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: `div[data-type=${this.name}]`,
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      setBlock:
+        (props: BlockWithMenuOptions) =>
+        ({ chain }) => {
+          return chain()
+            .insertContent({
+              type: this.name,
+              preserveWhitespace: true,
+              attrs: {
+                ...props,
+              },
+            })
+            .command(goToTrailingParagraph)
+            .run();
+        },
+    };
+  },
+});

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -2,7 +2,13 @@ import {
   BlockWithMenuComponent,
   EditableBlockWithMenuComponent,
 } from "./Components";
-import { goToTrailingParagraph, loadToDom, withViewWrapper } from "../utils";
+import {
+  goToTrailingParagraph,
+  loadToDom,
+  toggleAttributeOnClick,
+  toggleSpoilersOnKeydown,
+  withViewWrapper,
+} from "../utils";
 
 import { Node } from "@tiptap/core";
 import { PluginKey } from "prosemirror-state";
@@ -14,6 +20,7 @@ export interface BlockWithMenuOptions {
   width?: number;
   height?: number;
   spoilers?: boolean;
+  visible?: boolean;
 }
 
 export const PLUGIN_NAME = "blockWithMenu";
@@ -34,6 +41,9 @@ export const BlockWithMenuPlugin = Node.create<BlockWithMenuOptions>({
       spoilers: {
         default: false,
         parseHTML: (element) => element.getAttribute("data-spoilers"),
+      },
+      visible: {
+        default: false,
       },
       height: {
         default: 300,
@@ -94,5 +104,12 @@ export const BlockWithMenuPlugin = Node.create<BlockWithMenuOptions>({
     };
   },
 
-  // TODO: make spoilers revealable
+  addProseMirrorPlugins() {
+    return [
+      toggleAttributeOnClick({
+        name: this.name,
+        attribute: "data-visible",
+      }),
+    ];
+  },
 });

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -1,9 +1,8 @@
-import { EditableBlockWithMenuComponent, BlockWithMenuComponent } from "./Components";
 import {
-  goToTrailingParagraph,
-  loadToDom,
-  withViewWrapper,
-} from "../utils";
+  BlockWithMenuComponent,
+  EditableBlockWithMenuComponent,
+} from "./Components";
+import { goToTrailingParagraph, loadToDom, withViewWrapper } from "../utils";
 
 import { Node } from "@tiptap/core";
 import { PluginKey } from "prosemirror-state";
@@ -26,7 +25,7 @@ declare module "@tiptap/core" {
   }
 }
 
-export const ImagePlugin = Node.create<BlockWithMenuOptions>({
+export const BlockWithMenuPlugin = Node.create<BlockWithMenuOptions>({
   name: PLUGIN_NAME,
   group: "block",
 
@@ -34,12 +33,24 @@ export const ImagePlugin = Node.create<BlockWithMenuOptions>({
     return {
       spoilers: {
         default: false,
+        parseHTML: (element) => element.getAttribute("data-spoilers"),
+      },
+      height: {
+        default: 300,
+        parseHTML: (element) => element.getAttribute("data-height"),
+      },
+      width: {
+        default: 300,
+        parseHTML: (element) => element.getAttribute("data-height"),
       },
     };
   },
 
   renderHTML({ node }) {
-    return loadToDom(BlockWithMenuComponent, node.attrs as BlockWithMenuOptions);
+    return loadToDom(
+      BlockWithMenuComponent,
+      node.attrs as BlockWithMenuOptions
+    );
   },
 
   addNodeView() {

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -13,7 +13,10 @@ import { Node } from "@tiptap/core";
 import { PluginKey } from "prosemirror-state";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
-export const BlockWithMenuPluginKey = new PluginKey("BLockWithMenuPlugin");
+// This plugin is a base from which to extend other plugins with a shared set of features.
+// It is not intended to be used directly in the editor in an application.
+
+export const BlockWithMenuPluginKey = new PluginKey("BlockWithMenuPlugin");
 
 export interface BlockWithMenuOptions {
   width?: number;

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -46,14 +46,14 @@ export const BlockWithMenuPlugin = Node.create<BlockWithMenuOptions>({
         default: false,
       },
       height: {
-        default: 300,
+        default: undefined,
         parseHTML: (element) => {
           const rawHeight = element.getAttribute("data-height");
           return rawHeight ? parseFloat(rawHeight) : null;
         },
       },
       width: {
-        default: 300,
+        default: undefined,
         parseHTML: (element) => {
           const rawWidth = element.getAttribute("data-width");
           return rawWidth ? parseFloat(rawWidth) : null;

--- a/src/plugins/BlockWithMenu/Plugin.tsx
+++ b/src/plugins/BlockWithMenu/Plugin.tsx
@@ -1,15 +1,12 @@
 import {
   BlockBaseComponent,
-  BlockBaseProps,
   EditableBlockWithMenuComponent,
 } from "./Components";
 import {
   goToTrailingParagraph,
   loadToDom,
   toggleAttributeOnClick,
-  toggleSpoilersOnKeydown,
   withViewWrapper,
-  withViewWrapperOld,
 } from "../utils";
 
 import { Node } from "@tiptap/core";

--- a/src/plugins/BlockWithMenu/index.ts
+++ b/src/plugins/BlockWithMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./Plugin";

--- a/src/plugins/BlockWithMenu/package.json
+++ b/src/plugins/BlockWithMenu/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@bobaboard/tiptap-block-with-menu",
+  "type": "module",
+  "version": "0.0.1",
+  "exports": {
+    ".": {
+      "import": "./dist/tiptap-block-with-menu.js",
+      "require": "./dist/tiptap-block-with-menu.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsc && vite build",
+    "clean": "rm -rf node_modules && rm -rf dist"
+  },
+  "dependencies": {
+    "@linaria/babel-preset": "^4.4.3",
+    "@linaria/core": "^4.2.8",
+    "@linaria/react": "^4.3.6"
+  },
+  "devDependencies": {
+    "@linaria/vite": "^4.2.9",
+    "typescript": "^5.0.2"
+  }
+}

--- a/src/plugins/BlockWithMenu/vite.config.ts
+++ b/src/plugins/BlockWithMenu/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vite";
+import linaria from "@linaria/vite";
+import path from "path";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, "index.ts"),
+      name: "TipTapBlockWithMenu",
+      formats: ["cjs", "es"],
+    },
+    rollupOptions: {
+      external: ["react", "react-dom"],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+        },
+      },
+    },
+  },
+  plugins: [
+    react(),
+    linaria({
+      sourceMap: process.env.NODE_ENV !== "production",
+    }),
+  ],
+});

--- a/src/plugins/Image/Components.tsx
+++ b/src/plugins/Image/Components.tsx
@@ -6,9 +6,7 @@ import {
 import { ImageOptions, PLUGIN_NAME } from "./Plugin";
 import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 
-import {
-  Button,
-} from "../BlockSettingsMenu/BlockSettingsMenu";
+import { Button } from "../BlockSettingsMenu/BlockSettingsMenu";
 import React from "react";
 import { css } from "@linaria/core";
 
@@ -18,7 +16,11 @@ const imageComponentClass = css`
   }
 `;
 
-export const ImageComponent = (props: BlockBaseProps) => {
+export const ImageComponent = (
+  props: BlockBaseProps & {
+    onLoad?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
+  }
+) => {
   const attributes = props.attributes;
   return (
     <BlockBaseComponent
@@ -30,6 +32,7 @@ export const ImageComponent = (props: BlockBaseProps) => {
         src={attributes.src}
         alt={attributes.alt}
         style={{ display: "block", maxWidth: "100%" }}
+        onLoad={props.onLoad}
       />
     </BlockBaseComponent>
   );
@@ -58,6 +61,14 @@ export const EditableImageComponent = (
       <ImageComponent
         attributes={attributes}
         pluginName={PLUGIN_NAME}
+        onLoad={(event) => {
+          const image = event.target as HTMLElement;
+          if (image.tagName !== "IMG") {
+            return;
+          }
+          const rect = image.getBoundingClientRect();
+          props.updateAttributes?.({ width: rect.width, height: rect.height });
+        }}
       />
     </NodeViewWrapper>
   );

--- a/src/plugins/Image/Components.tsx
+++ b/src/plugins/Image/Components.tsx
@@ -1,43 +1,16 @@
-import { ArrowDown, ArrowUp, EyeAlt, EyeOff, Trash } from "iconoir-react";
 import {
-  BlockSettingsMenu,
-  Button,
-  ToggleButton,
-} from "../BlockSettingsMenu/BlockSettingsMenu";
+  BlockBaseComponent,
+  BlockBaseMenu,
+  BlockBaseProps,
+} from "../BlockWithMenu/Components";
 import { ImageOptions, PLUGIN_NAME } from "./Plugin";
 import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 
+import {
+  Button,
+} from "../BlockSettingsMenu/BlockSettingsMenu";
 import React from "react";
 import { css } from "@linaria/core";
-
-const ImageOptionsMenu = (props: {
-  spoilers: boolean;
-  onToggleSpoilers: (spoilers: boolean) => void;
-  onDeleteRequest: () => void;
-  onInsertAbove: () => void;
-  onInsertBelow: () => void;
-}) => {
-  return (
-    <BlockSettingsMenu>
-      <ToggleButton
-        value={!!props.spoilers}
-        title="Toggle Spoilers"
-        onValueChange={props.onToggleSpoilers}
-      >
-        {props.spoilers ? <EyeAlt /> : <EyeOff />}
-      </ToggleButton>
-      <Button title="Delete Image" onClick={props.onDeleteRequest}>
-        <Trash />
-      </Button>
-      <Button title="Insert Paragraph Above" onClick={props.onInsertAbove}>
-        Insert Paragraph <ArrowUp />
-      </Button>
-      <Button title="Insert Paragraph Below" onClick={props.onInsertBelow}>
-        Insert Paragraph <ArrowDown />
-      </Button>
-    </BlockSettingsMenu>
-  );
-};
 
 const imageComponentClass = css`
   picture img {
@@ -45,20 +18,20 @@ const imageComponentClass = css`
   }
 `;
 
-export const ImageComponent = (props: ImageOptions) => {
+export const ImageComponent = (props: BlockBaseProps) => {
+  const attributes = props.attributes;
   return (
-    <picture
+    <BlockBaseComponent
+      {...props}
       className={imageComponentClass}
-      data-type={PLUGIN_NAME}
-      data-spoilers={props.spoilers}
-      style={{ display: "block", maxWidth: "100%" }}
+      enclosingTag={"picture"}
     >
       <img
-        src={props.src}
-        alt={props.alt}
+        src={attributes.src}
+        alt={attributes.alt}
         style={{ display: "block", maxWidth: "100%" }}
       />
-    </picture>
+    </BlockBaseComponent>
   );
 };
 
@@ -68,45 +41,23 @@ export const EditableImageComponent = (
   const attributes = props.node.attrs as ImageOptions;
   return (
     <NodeViewWrapper data-type={PLUGIN_NAME}>
-      <ImageOptionsMenu
-        spoilers={!!attributes.spoilers}
-        onToggleSpoilers={(spoilers) =>
-          props.updateAttributes?.({
-            spoilers,
-          })
-        }
-        onDeleteRequest={() => props.deleteNode?.()}
-        onInsertAbove={() => {
-          if (props.getPos) {
-            props.editor
-              ?.chain()
-              .insertContentAt(
-                props.getPos() > 0 ? props.getPos() - 1 : 0,
-                "<p></p>",
-                {
-                  updateSelection: true,
-                }
-              )
-              .focus()
-              .run();
-          }
-        }}
-        onInsertBelow={() => {
-          if (props.getPos) {
-            props.editor
-              ?.chain()
-              .insertContentAt(props.getPos() + 1, "<p></p>", {
-                updateSelection: true,
-              })
-              .focus()
-              .run();
-          }
-        }}
-      />
+      <BlockBaseMenu {...props} deleteTitle="Image">
+        <Button
+          title="set alt text"
+          onClick={() => {
+            const alt = window.prompt("Set alt text:", attributes.alt);
+            if (!alt) {
+              return;
+            }
+            props.updateAttributes?.({ alt });
+          }}
+        >
+          Set Alt Text
+        </Button>
+      </BlockBaseMenu>
       <ImageComponent
-        src={attributes.src}
-        alt={attributes.alt}
-        spoilers={attributes.spoilers}
+        attributes={attributes}
+        pluginName={PLUGIN_NAME}
       />
     </NodeViewWrapper>
   );

--- a/src/plugins/Image/Plugin.tsx
+++ b/src/plugins/Image/Plugin.tsx
@@ -1,9 +1,5 @@
 import { EditableImageComponent, ImageComponent } from "./Components";
-import {
-  goToTrailingParagraph,
-  loadToDom,
-  withViewWrapper,
-} from "../utils";
+import { goToTrailingParagraph, loadToDom, withViewWrapperOld } from "../utils";
 
 import { Node } from "@tiptap/core";
 import { PluginKey } from "prosemirror-state";
@@ -56,7 +52,7 @@ export const ImagePlugin = Node.create<ImageOptions>({
     return ReactNodeViewRenderer(
       this.editor.isEditable
         ? EditableImageComponent
-        : withViewWrapper(PLUGIN_NAME, ImageComponent)
+        : withViewWrapperOld(PLUGIN_NAME, ImageComponent)
     );
   },
 

--- a/src/plugins/Image/Plugin.tsx
+++ b/src/plugins/Image/Plugin.tsx
@@ -1,13 +1,7 @@
 import { BlockWithMenuOptions, BlockWithMenuPlugin } from "../BlockWithMenu";
 import { EditableImageComponent, ImageComponent } from "./Components";
-import {
-  goToTrailingParagraph,
-  loadToDom,
-  withViewWrapper,
-  withViewWrapperOld,
-} from "../utils";
+import { goToTrailingParagraph, loadToDom, withViewWrapper } from "../utils";
 
-import { Node } from "@tiptap/core";
 import { PluginKey } from "prosemirror-state";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 

--- a/src/plugins/Image/package.json
+++ b/src/plugins/Image/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf node_modules && rm -rf dist"
   },
   "dependencies": {
+    "@bobaboard/tiptap-block-with-menu": "*",
     "@linaria/babel-preset": "^4.4.3",
     "@linaria/core": "^4.2.8",
     "@linaria/react": "^4.3.6"

--- a/src/plugins/InlineSpoilers/Plugin.tsx
+++ b/src/plugins/InlineSpoilers/Plugin.tsx
@@ -4,9 +4,9 @@ import {
   markPasteRule,
   mergeAttributes,
 } from "@tiptap/core";
+import { toggleAttributeOnClick, toggleSpoilersOnKeydown } from "../utils";
 
 import { PluginKey } from "@tiptap/pm/state";
-import { toggleAttributeOnClick } from "../utils";
 
 export interface InlineSpoilersOptions {
   visible?: boolean;
@@ -32,33 +32,6 @@ declare module "@tiptap/core" {
 // https://github.com/ueberdosis/tiptap/blob/781cdfa54ebd1ba4733f63bb9d5844a59703a7e8/packages/extension-strike/src/strike.ts#L31
 export const inputRegex = /(?:^|\s)((?:\|\|)((?:[^\|]+))(?:\|\|))$/;
 export const pasteRegex = /(?:^|\s)((?:\|\|)((?:[^\|]+))(?:\|\|))/g;
-
-const toggleSpoilersOnKeydown = (event: KeyboardEvent) => {
-  console.log("in keydown event");
-  if (
-    event.key !== "R" ||
-    event.ctrlKey ||
-    event.metaKey ||
-    !event.altKey ||
-    !event.shiftKey
-  ) {
-    console.log("no key match");
-    return;
-  }
-  if (document.activeElement?.getAttribute("data-type") !== PLUGIN_NAME) {
-    console.log("activeElement", document.activeElement);
-    return;
-  }
-  const spoilersElement = document.activeElement;
-  const currentValue = spoilersElement.getAttribute("data-visible");
-  if (!currentValue) {
-    console.log("element attribute has no currentValue");
-    return;
-  }
-  const newValue = currentValue === "false" ? "true" : "false";
-  console.log(`toggling data-visible from ${currentValue} to ${newValue}`);
-  spoilersElement.setAttribute("data-visible", newValue);
-};
 
 export const InlineSpoilersPlugin = Mark.create<InlineSpoilersOptions>({
   name: PLUGIN_NAME,
@@ -150,22 +123,6 @@ export const InlineSpoilersPlugin = Mark.create<InlineSpoilersOptions>({
         type: this.type,
       }),
     ];
-  },
-
-  // I feel like there should be a better way to do this,
-  // but ProseMirror's handleKeyDown doesn't seem to work in a non-editable editor
-  onCreate() {
-    if (this.editor.isEditable) {
-      return;
-    }
-    document.addEventListener("keydown", toggleSpoilersOnKeydown);
-  },
-
-  onDestroy() {
-    if (this.editor.isEditable) {
-      return;
-    }
-    document.removeEventListener("keydown", toggleSpoilersOnKeydown);
   },
 
   addProseMirrorPlugins() {

--- a/src/plugins/InlineSpoilers/Plugin.tsx
+++ b/src/plugins/InlineSpoilers/Plugin.tsx
@@ -82,7 +82,7 @@ export const InlineSpoilersPlugin = Mark.create<InlineSpoilersOptions>({
     return {
       // Editing functions break if you add tabindex=0,
       // which we want in the view only state to allow revealing spoilers via keyboard navigation,
-      // but we can't directly assess this.editor in renderHTML so it needs to be set via configuration based on the editor props.
+      // but we can't directly access this.editor in renderHTML so it needs to be set via configuration based on the editor props.
       focusable: false,
     };
   },

--- a/src/plugins/OEmbed/Plugin.tsx
+++ b/src/plugins/OEmbed/Plugin.tsx
@@ -1,5 +1,5 @@
 import { OEmbedLoader, OEmbedPlaceholder } from "./Components";
-import { goToTrailingParagraph, loadToDom, withViewWrapper } from "../utils";
+import { goToTrailingParagraph, loadToDom, withViewWrapperOld } from "../utils";
 
 import { Node } from "@tiptap/core";
 import { PluginKey } from "prosemirror-state";
@@ -65,7 +65,7 @@ export const OEmbedPlugin = Node.create<{
     return ReactNodeViewRenderer(
       this.editor.isEditable
         ? OEmbedLoader
-        : withViewWrapper(PLUGIN_NAME, OEmbedLoader)
+        : withViewWrapperOld(PLUGIN_NAME, OEmbedLoader)
     );
   },
 

--- a/src/plugins/utils.tsx
+++ b/src/plugins/utils.tsx
@@ -113,3 +113,43 @@ export const toggleAttributeOnClick = ({
     },
   });
 };
+
+export const toggleSpoilersOnKeydown = (event: KeyboardEvent) => {
+  console.log("in keydown event");
+  if (
+    event.key !== "R" ||
+    event.ctrlKey ||
+    event.metaKey ||
+    !event.altKey ||
+    !event.shiftKey
+  ) {
+    console.log("no key match");
+    return;
+  }
+  if (
+    document.activeElement?.getAttribute("data-type") !== "inlineSpoilers" &&
+    !document.activeElement?.getAttribute("data-spoilers")
+  ) {
+    console.log("data-type", document.activeElement?.getAttribute("data-type"));
+    console.log(
+      "data-spoilers",
+      document.activeElement?.getAttribute("data-spoilers")
+    );
+    console.log("activeElement", document.activeElement);
+    return;
+  }
+  const spoilersElement = document.activeElement;
+  const currentValue = spoilersElement?.getAttribute("data-visible");
+  if (!currentValue) {
+    console.log("data-visible has no currentValue");
+    return;
+  }
+  const newValue = currentValue === "false" ? "true" : "false";
+  console.log(`toggling data-visible from ${currentValue} to ${newValue}`);
+  console.log("spoilersElement", spoilersElement);
+  spoilersElement.setAttribute("data-visible", newValue);
+  console.log(
+    "after update, data-visible",
+    spoilersElement?.getAttribute("data-visible")
+  );
+};

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -13,6 +13,7 @@
     "@bobaboard/tiptap-image": "*",
     "@bobaboard/tiptap-oembed": "*",
     "@bobaboard/tiptap-inline-spoilers": "*",
+    "@bobaboard/tiptap-block-with-menu": "*",
     "@bobaboard/tiptap-storybook-inspector": "*",
     "@storybook/addon-actions": "^7.0.0-beta.28",
     "@storybook/addon-essentials": "^7.0.0-beta.28",

--- a/storybook/stories/Editor.stories.tsx
+++ b/storybook/stories/Editor.stories.tsx
@@ -68,7 +68,7 @@ export const Editable: Story = {
   args: {
     editable: true,
     addedExtensions: [Italic],
-    initialContent: `<picture data-type="image"><img src="https://placekitten.com/200/300" /></picture>`,
+    initialContent: `<picture data-type="image"><img src="https://placekitten.com/200/300" /></picture><picture data-type="image" data-spoilers="true"><img src="https://placekitten.com/200/300" alt="A kitten" /></picture>`,
   },
 };
 

--- a/storybook/stories/Editor.stories.tsx
+++ b/storybook/stories/Editor.stories.tsx
@@ -114,6 +114,8 @@ export const Italics: Story = {
 export const BlockWithMenu: Story = {
   args: {
     ...Editable.args,
+    // The first of the divs here intentionally leaves out data-width and data-height for testing purposes,
+    // and therefore will appear with no size on load, only the menu will show for the block.
     initialContent: `<div data-type="blockWithMenu" data-spoilers="true"></div><div data-type="blockWithMenu" data-height="100" data-width="800"></div>`,
     addedExtensions: [BlockWithMenuPlugin],
     customFloatingMenuButtons: [

--- a/storybook/stories/Editor.stories.tsx
+++ b/storybook/stories/Editor.stories.tsx
@@ -117,13 +117,7 @@ export const BlockWithMenu: Story = {
             <button
               title="add block"
               aria-label="add block"
-              onClick={() =>
-                editor
-                  .chain()
-                  .focus()
-                  .setBlock({ height: 200, width: 100 })
-                  .run()
-              }
+              onClick={() => editor.chain().focus().setBlock({}).run()}
             >
               Block
             </button>
@@ -138,6 +132,7 @@ export const ViewOnlyBlocks: Story = {
   args: {
     ...BlockWithMenu.args,
     editable: false,
+    initialContent: `<div data-type="blockWithMenu" data-spoilers="true" data-height="300" data-width="300"></div><div data-type="blockWithMenu" data-height="100" data-width="800"></div><p>or if I'm worried about revealing <span data-type="inlineSpoilers">SPOILERS!!!</span> for a thing</p>`,
   },
 };
 

--- a/storybook/stories/Editor.stories.tsx
+++ b/storybook/stories/Editor.stories.tsx
@@ -68,7 +68,7 @@ export const Editable: Story = {
   args: {
     editable: true,
     addedExtensions: [Italic],
-    initialContent: `<picture data-type="image"><img src="https://placekitten.com/200/300" /></picture><picture data-type="image" data-spoilers="true"><img src="https://placekitten.com/200/300" alt="A kitten" /></picture>`,
+    initialContent: `<picture data-type="image"><img src="https://placekitten.com/200/300" /></picture>`,
   },
 };
 
@@ -76,6 +76,13 @@ export const ViewOnly: Story = {
   args: {
     ...Editable.args,
     editable: false,
+  },
+};
+
+export const ViewOnlyImagesSpoilers: Story = {
+  args: {
+    ...ViewOnly.args,
+    initialContent: `<picture data-type="image"><img src="https://placekitten.com/200/300" /></picture><picture data-type="image" data-spoilers="true"><img src="https://placekitten.com/200/300" alt="A kitten" /></picture><picture data-type="image" data-spoilers="true" data-width="200" data-height="300"><img src="https://placekitten.com/200/300" alt="A kitten" /></picture>`,
   },
 };
 

--- a/storybook/stories/Editor.stories.tsx
+++ b/storybook/stories/Editor.stories.tsx
@@ -1,6 +1,7 @@
 import { DEFAULT_EXTENSIONS, Editor } from "../../src/editor";
 import { Meta, StoryObj } from "@storybook/react";
 
+import { BlockWithMenuPlugin } from "@bobaboard/tiptap-block-with-menu";
 import Blockquote from "@tiptap/extension-blockquote";
 import BulletList from "@tiptap/extension-bullet-list";
 import Code from "@tiptap/extension-code";
@@ -35,6 +36,7 @@ const meta = {
       OrderedList,
       Strike,
       Underline,
+      BlockWithMenuPlugin,
     ]),
     (Story, ctx) => {
       return (
@@ -99,6 +101,43 @@ export const Italics: Story = {
         },
       },
     ],
+  },
+};
+
+export const BlockWithMenu: Story = {
+  args: {
+    ...Editable.args,
+    initialContent: `<div data-type="blockWithMenu" data-spoilers="true"></div><div data-type="blockWithMenu" data-height="100" data-width="800"></div>`,
+    addedExtensions: [BlockWithMenuPlugin],
+    customFloatingMenuButtons: [
+      {
+        extensionName: "blockWithMenu",
+        menuButton: ({ editor }: MenuButtonProps) => {
+          return (
+            <button
+              title="add block"
+              aria-label="add block"
+              onClick={() =>
+                editor
+                  .chain()
+                  .focus()
+                  .setBlock({ height: 200, width: 100 })
+                  .run()
+              }
+            >
+              Block
+            </button>
+          );
+        },
+      },
+    ],
+  },
+};
+
+export const ViewOnlyBlocks: Story = {
+  args: {
+    ...BlockWithMenu.args,
+    editable: false,
   },
 };
 


### PR DESCRIPTION
Adds a BlockWithMenu plugin for use as a base to extend other plugins from. Includes functionality for spoilers, deleting, inserting paragraphs above and below, and width and height attributes.

Reworks Image plugin to extend BlockWithMenu plugin. Additionally, adds detecting size on image load and a button for adding alt text.