### PR TITLE
Fix block-with-menu package exports

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -10,7 +10,7 @@ import {
 import { BubbleMenuOptions, MenuOption } from "./BubbleMenu";
 import { Mark, Node, isTextSelection } from "@tiptap/core";
 
-import { BlockWithMenuPlugin } from "../plugins/BlockWithMenu";
+import { BlockWithMenuPlugin } from "@bobaboard/tiptap-block-with-menu";
 import Bold from "@tiptap/extension-bold";
 import Document from "@tiptap/extension-document";
 import { FloatingMenuOptions } from "./FloatingMenu";

--- a/src/plugins/BlockWithMenu/index.ts
+++ b/src/plugins/BlockWithMenu/index.ts
@@ -1,1 +1,3 @@
 export * from "./Plugin";
+export { BlockBaseComponent, BlockBaseMenu } from "./Components";
+export type { BlockBaseMenuProps, BlockBaseProps } from "./Components";

--- a/src/plugins/Image/Components.tsx
+++ b/src/plugins/Image/Components.tsx
@@ -2,7 +2,7 @@ import {
   BlockBaseComponent,
   BlockBaseMenu,
   BlockBaseProps,
-} from "../BlockWithMenu/Components";
+} from "@bobaboard/tiptap-block-with-menu";
 import { ImageOptions, PLUGIN_NAME } from "./Plugin";
 import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 

--- a/src/plugins/Image/Plugin.tsx
+++ b/src/plugins/Image/Plugin.tsx
@@ -1,4 +1,7 @@
-import { BlockWithMenuOptions, BlockWithMenuPlugin } from "../BlockWithMenu";
+import {
+  BlockWithMenuOptions,
+  BlockWithMenuPlugin,
+} from "@bobaboard/tiptap-block-with-menu";
 import { EditableImageComponent, ImageComponent } from "./Components";
 import { goToTrailingParagraph, loadToDom, withViewWrapper } from "../utils";
 


### PR DESCRIPTION
Properly exports the components needed in child plugins from the block-with-menu package, and updates imports to ensure they are coming from the package not a relative path.